### PR TITLE
feat(entry_maker): add prettier highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ require("telescope").setup {
       col_hl = "EgrepifyCol",         -- default, not required, links to `Constant`
       title = true,                   -- default, not required, show filename as title rather than inline
       filename_hl = "EgrepifyFile",   -- default, not required, links to `Title`
+      directory_hl = "EgrepifyFile"   -- default, not required, links to `Title`
       -- suffix = long line, see screenshot
       -- EXAMPLE ON HOW TO ADD PREFIX!
       prefixes = {

--- a/doc/telescope-egrepify.txt
+++ b/doc/telescope-egrepify.txt
@@ -115,6 +115,7 @@ PickerConfig                                                      *PickerConfig*
         {permutations}       (boolean)   search permutations of sub-tokens of prompt, implies AND true
         {prefixes}           (table)     prefixes for `rg` input, see |telescope-egrepify.prefix|
         {filename_hl}        (string)    hl for title (default: `EgrepifyFile` w/ link to `Title`)
+        {directory_hl}       (string)    hl for directory (default: link to `EgrepifyFile`)
         {title}              (boolean)   filename as title, false to inline (default: true)
         {title_suffix}       (string)    string after filename title, only if `title == true` (default: " " .. "──────────")
         {title_suffix_hl}    (string)    title suffix hl [`EgrepifySuffix`, links to `Comment`]

--- a/lua/telescope/_extensions/egrepify.lua
+++ b/lua/telescope/_extensions/egrepify.lua
@@ -102,6 +102,7 @@ local egrep_picker = require "telescope._extensions.egrepify.picker"
 
 -- Initialize highlights
 vim.api.nvim_set_hl(0, "EgrepifyFile", { link = "Title", default = true })
+vim.api.nvim_set_hl(0, "EgrepifyDirectory", { link = "EgrepifyFile", default = true })
 vim.api.nvim_set_hl(0, "EgrepifySuffix", { link = "Comment", default = true })
 vim.api.nvim_set_hl(0, "EgrepifyLnum", { link = "Constant", default = true })
 vim.api.nvim_set_hl(0, "EgrepifyCol", { link = "Constant", default = true })

--- a/lua/telescope/_extensions/egrepify/config.lua
+++ b/lua/telescope/_extensions/egrepify/config.lua
@@ -19,6 +19,7 @@ _TelescopeEgrepifyConfig = {
   use_prefixes = true,
   title = true,
   filename_hl = "EgrepifyFile",
+  directory_hl = "EgrepifyFile",
   title_suffix = title_suffix,
   title_suffix_hl = "EgrepifySuffix",
   grep_open_files = false,

--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -1,5 +1,6 @@
 local ts_utils = require "telescope.utils"
 local egrep_conf = require("telescope._extensions.egrepify.config").values
+local grepify_utils = require "telescope._extensions.egrepify.utils"
 
 local os_sep = require("plenary.path").path.sep
 local str = require "plenary.strings"
@@ -106,21 +107,27 @@ end
 
 local function title_display(filename, _, opts)
   local display_filename = ts_utils.transform_path({ cwd = opts.cwd }, filename)
+  local display_dirname, display_tail = grepify_utils.get_path_and_tail(display_filename, { show_sep = true })
   local suffix_ = opts.title_suffix or ""
   local display, hl_group = ts_utils.transform_devicons(display_filename, display_filename .. suffix_, false)
   local offset = find_whitespace(display)
-  local end_filename = offset + #display_filename
-  local end_suffix = end_filename + #opts.title_suffix
+  local end_dirname = offset + #display_dirname
+  local end_tail = end_dirname + #display_tail
+  local end_suffix = end_tail + #opts.title_suffix
   if hl_group then
     return display,
       {
         { { 0, offset }, hl_group },
         {
-          { offset, end_filename },
+          { offset, end_dirname },
+          "Directory",
+        },
+        {
+          { end_dirname, end_tail },
           opts.filename_hl,
         },
         suffix_ ~= "" and {
-          { end_filename, end_suffix },
+          { end_tail, end_suffix },
           opts.title_suffix_hl,
         } or nil,
       }

--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -120,7 +120,7 @@ local function title_display(filename, _, opts)
         { { 0, offset }, hl_group },
         {
           { offset, end_dirname },
-          "Directory",
+          opts.directory_hl,
         },
         {
           { end_dirname, end_tail },

--- a/lua/telescope/_extensions/egrepify/picker.lua
+++ b/lua/telescope/_extensions/egrepify/picker.lua
@@ -66,6 +66,7 @@ end
 ---@field permutations boolean search permutations of sub-tokens of prompt, implies AND true
 ---@field prefixes table prefixes for `rg` input, see |telescope-egrepify.prefix|
 ---@field filename_hl string hl for title (default: `EgrepifyFile` w/ link to `Title`)
+---@field directory_hl string hl for directory (default: link to `EgrepfyFile`)
 ---@field title boolean filename as title, false to inline (default: true)
 ---@field title_suffix string string after filename title, only if `title == true` (default: " " .. "──────────")
 ---@field title_suffix_hl string title suffix hl [`EgrepifySuffix`, links to `Comment`]

--- a/lua/telescope/_extensions/egrepify/utils.lua
+++ b/lua/telescope/_extensions/egrepify/utils.lua
@@ -109,4 +109,21 @@ M.permutations = function(tokens)
   return string.format("%s%s%s", "(", table.concat(result, "|"), ")")
 end
 
+---Get the tail of the path and the directory to display.
+---e.g. .config/nvim/init.lua -> .config/nvim, init.lua
+---@param file_path string
+---@param opts table
+---@return string directory # Directory path to display
+---@return string tail # The tail of the path (file name in most case).
+M.get_path_and_tail = function(file_path, opts)
+  local tail = require("telescope.utils").path_tail(file_path)
+  local path_without_tail = require("plenary.strings").truncate(file_path, #file_path - #tail, "")
+  if opts.show_sep then
+    return path_without_tail, tail
+  end
+
+  local directory = require("telescope.utils").transform_path({ path_display = { "truncate" } }, path_without_tail)
+  return directory, tail
+end
+
 return M


### PR DESCRIPTION
## Description

This pull request introduces a feature enhancement: users can now configure different highlight groups for file names and directory names.

## Changes Introduced

- Added the functionality to specify distinct highlight groups for file names and directory names.
- Updated the plugin documentation to reflect the new options.

## Example
```lua
require("telescope").setup {
  extensions = {
    egrepify = {
      -- ...
	  directory_hl = "Directory"
	}
  }
}
```

Now, users can customize the highlighting of file names and directory names separately according to their preferences.

![image](https://github.com/ushmz/telescope-egrepify.nvim/assets/44394399/7ec10160-4981-4ae6-b5a2-ec18e4cccc13)